### PR TITLE
Add ARI IDN implementation and turn on for .BIZ

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Extensions/BIZ.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/BIZ.pm
@@ -65,7 +65,7 @@ See the LICENSE file that comes with this distribution for more details.
 
 ####################################################################################################
 
-sub default_extensions { return qw/GracePeriod SecDNS11/; }
+sub default_extensions { return qw/GracePeriod SecDNS11 IDNARI/; }
 
 ####################################################################################################
 1;

--- a/lib/Net/DRI/Protocol/EPP/Extensions/IDNARI.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/IDNARI.pm
@@ -1,0 +1,45 @@
+package Net::DRI::Protocol::EPP::Extensions::IDNARI;
+
+use strict;
+use warnings;
+
+use Net::DRI::Util;
+use Net::DRI::Exception;
+
+our $VERSION=do { my @r=(q$Revision: 1.7 $=~/\d+/g); sprintf("%d".".%02d" x $#r, @r); };
+our $NS='urn:ar:params:xml:ns:idn-1.0';
+
+####################################################################################################
+
+sub register_commands
+{
+ my ($class,$version)=@_;
+ my %tmp=(
+           create => [ \&create, undef ],
+         );
+
+ return { 'domain' => \%tmp };
+}
+
+####################################################################################################
+
+sub add_language
+{
+ my ($tag,$epp,$domain,$rd)=@_;
+ my $mes=$epp->message();
+
+ if (Net::DRI::Util::has_key($rd,'language'))
+ {
+  Net::DRI::Exception::usererr_invalid_parameters('IDN language tag must be of type XML schema language') unless Net::DRI::Util::xml_is_language($rd->{language});
+  my $eid=$mes->command_extension_register($tag,sprintf('xmlns:idn="%s" xsi:schemaLocation="%s idn-1.0.xsd"',$NS,$NS));
+  $mes->command_extension($eid,['idn:languageTag', $rd->{language}]);
+ }
+}
+
+sub create
+{
+ return add_language('idn:create',@_);
+}
+
+####################################################################################################
+1;


### PR DESCRIPTION
I added an EPP extension to implement ARI IDN variant when creating
domains. I turned it on for BIZ plugin, but it can be used for any
other plugin which supports this variant.

Format:
<extension>
 <idn:create xmlns:idn="urn:ar:params:xml:ns:idn-1.0" xsi:schemaLocation="urn:ar:params:xml:ns:idn-1.0 idn-1.0.xsd">
  <idn:languageTag>sv</languageTag>
 </idn:create>
</extension>

Resolves PROD-375.

ChangeLog:
* [FIX] Added IDN support for NeuStar (.BIZ) domains.
* [IMPROVEMENT] Added implementation of EPP extension for ARI IDN variant.