### PR TITLE
Turn on DNSSEC for Hexonet

### DIFF
--- a/lib/Net/DRI/Protocol/EPP/Extensions/ISPAPI.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/ISPAPI.pm
@@ -71,7 +71,7 @@ See the LICENSE file that comes with this distribution for more details.
 
 ####################################################################################################
 
-sub default_extensions { return qw/ISPAPI::KeyValue ISPAPI::Message GracePeriod/; }
+sub default_extensions { return qw/ISPAPI::KeyValue ISPAPI::Message GracePeriod SecDNS11/; }
 
 ####################################################################################################
 1;


### PR DESCRIPTION
Added DNSSEC extension for Hexonet.

Resolves PROD-739.