### PR TITLE
Extend SE plugin to support .TEST TLD

### DIFF
--- a/lib/Net/DRI/DRD/SE.pm
+++ b/lib/Net/DRI/DRD/SE.pm
@@ -85,7 +85,7 @@ sub new
 }
 
 sub name     { return 'se'; }
-sub tlds     { return ('SE'); }
+sub tlds     { return ('SE', 'TEST'); }
 sub periods  { return map { DateTime::Duration->new(months => $_) } (12..120); }
 sub object_types { return ('domain','contact','ns'); }
 sub profile_types { return qw/epp whois/; }


### PR DESCRIPTION
IIS SE Registry changed its policy, they provide .test TLD for testing
instead of .se.

Resolves PROD-2013.

ChangeLog:
* [IMPROVEMENT] - Extended SE plugin to support .TEST TLD