### PR TITLE
Add TLS 1.2 support for .no

### DIFF
--- a/lib/Net/DRI/DRD/NO.pm
+++ b/lib/Net/DRI/DRD/NO.pm
@@ -97,7 +97,7 @@ sub profile_types { return qw/epp/; }
 sub transport_protocol_default {
     my ($self,$type)=@_;
     
-    return ('Net::DRI::Transport::Socket',{},'Net::DRI::Protocol::EPP::Extensions::NO',{}) if $type eq 'epp';
+    return ('Net::DRI::Transport::Socket',{'ssl_version'=>'TLSv12', 'ssl_cipher_list' => undef},'Net::DRI::Protocol::EPP::Extensions::NO',{}) if $type eq 'epp';
 # suppress until whois is supported
 #return ('Net::DRI::Transport::Socket',{remote_host=>'whois.norid.no'},'Net::DRI::Protocol::Whois',{}) if $type eq 'whois';
 


### PR DESCRIPTION
Resolves PROD-2214

ChangeLog:
[IMPROVEMENT] Added TLS 1.2 support for .no domains.