### PR TITLE
Update domain-ext to 2.4 for EUrid

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-libnet-dri-perl (0.96-67atomia) unstable; urgency=low
+libnet-dri-perl (0.96-68atomia) unstable; urgency=low
+  * Update domain-ext to 2.4 for EUrid.
   * Switched to TLS 1.2 for .no domains.
   * Adjusting to new EURid's (release march 2019) code breaking feature.
   * Added transfer extra data parsing support for AT plugin

--- a/lib/Net/DRI/Protocol/EPP/Extensions/EURid.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/EURid.pm
@@ -75,8 +75,8 @@ sub setup
  my $version=$self->version();
 
  my $default_ns_versions = {
-		'domain-ext_version' => '2.3',
-		'domain-ext_version_xsd' => '2.3',
+		'domain-ext_version' => '2.4',
+		'domain-ext_version_xsd' => '2.4',
 		'contact-ext_version' => '1.3',
 		'contact-ext_version_xsd' => '1.3',
 		'nsgroup_version' => '1.1',

--- a/perl-Net-DRI.spec
+++ b/perl-Net-DRI.spec
@@ -10,7 +10,7 @@
 Summary: Interface to Domain Name Registries/Registrars/Resellers
 Name: perl-Net-DRI
 Version: 0.96
-Release: 67atomia
+Release: 68atomia
 License: Artistic/GPL
 Group: Applications/CPAN
 URL: http://search.cpan.org/dist/Net-DRI/
@@ -75,6 +75,9 @@ find eg/ -type f -exec %{__chmod} a-x {} \;
 %{perl_vendorlib}/Net/DRI.pm
 
 %changelog
+* Fri Jun 12 2020 Stevan Kostic <stevan.kostic@atomia.com> - 0.96-68atomia
+- Update domain-ext to 2.4 for EUrid.
+
 * Thu Apr 23 2020 Sasa Mladenovic <sasa.mladenovic@atomia.com> - 0.96-67atomia
 - Updated to version 0.96-67atomia.
 


### PR DESCRIPTION
Update domain-ext to 2.4 for EUrid since they announced code breaking
changes in that version and bumped version.

Resolves PROD-2253.

ChangeLog:
* [IMPROVEMENT] Update domain-ext to 2.4 for EUrid.