### PR TITLE
Activate TLS1.2 on SWITCH plugin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-libnet-dri-perl (0.96-68atomia) unstable; urgency=low
+libnet-dri-perl (0.96-69atomia) unstable; urgency=low
+  * Activate TLS1.2 on SWITCH plugin
   * Update domain-ext to 2.4 for EUrid.
   * Switched to TLS 1.2 for .no domains.
   * Adjusting to new EURid's (release march 2019) code breaking feature.

--- a/lib/Net/DRI/DRD/SWITCH.pm
+++ b/lib/Net/DRI/DRD/SWITCH.pm
@@ -92,7 +92,7 @@ sub transport_protocol_default
 {
  my ($self,$type)=@_;
 
- return ('Net::DRI::Transport::Socket',{},'Net::DRI::Protocol::EPP::Extensions::SWITCH',{}) if $type eq 'epp';
+ return ('Net::DRI::Transport::Socket',{'ssl_version'=>'TLSv12', 'ssl_cipher_list' => undef},'Net::DRI::Protocol::EPP::Extensions::SWITCH',{}) if $type eq 'epp';
 ## return ('Net::DRI::Transport::Socket',{remote_host=>'whois.switch.ch'},'Net::DRI::Protocol::Whois',{}) if $type eq 'whois';
  return;
 }

--- a/perl-Net-DRI.spec
+++ b/perl-Net-DRI.spec
@@ -10,7 +10,7 @@
 Summary: Interface to Domain Name Registries/Registrars/Resellers
 Name: perl-Net-DRI
 Version: 0.96
-Release: 68atomia
+Release: 69atomia
 License: Artistic/GPL
 Group: Applications/CPAN
 URL: http://search.cpan.org/dist/Net-DRI/
@@ -75,6 +75,9 @@ find eg/ -type f -exec %{__chmod} a-x {} \;
 %{perl_vendorlib}/Net/DRI.pm
 
 %changelog
+* Tue Okt 27 2020 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-69atomia
+- Update to version 0.96-69atomia.
+
 * Fri Jun 12 2020 Stevan Kostic <stevan.kostic@atomia.com> - 0.96-68atomia
 - Update domain-ext to 2.4 for EUrid.
 


### PR DESCRIPTION
Activated TLS1.2 on SWITCH plugin.

Resolves PROD-2463.

ChangeLog:
* [FIX] Activated TLS1.2 on SWITCH plugin.