### PR TITLE
Fix transfer of .at domains

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-libnet-dri-perl (0.96-70atomia) unstable; urgency=low
+libnet-dri-perl (0.96-71atomia) unstable; urgency=low
+  * Fix transfer of .at domains.
   * Get authcode directly from opensrs.
   * Activate TLS1.2 on SWITCH plugin
   * Update domain-ext to 2.4 for EUrid.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-libnet-dri-perl (0.96-71atomia) unstable; urgency=low
+libnet-dri-perl (0.96-72atomia) unstable; urgency=low
+  * Fix transfer of .at domains.
   * Add support for DNSSEC in OpenSRS plugin.
   * Get authcode directly from opensrs.
   * Activate TLS1.2 on SWITCH plugin

--- a/lib/Net/DRI/Protocol/EPP/Extensions/AT/Domain.pm
+++ b/lib/Net/DRI/Protocol/EPP/Extensions/AT/Domain.pm
@@ -152,7 +152,7 @@ sub extonly {
                        [
                                ['transfer',
 
-                                       { 'op' => 'execute' },
+                                       { 'op' => 'request' },
                                        [ 'domain:transfer', \%domns, [ 'domain:name', $domain ]
                                        ]
                                ],

--- a/perl-Net-DRI.spec
+++ b/perl-Net-DRI.spec
@@ -75,6 +75,9 @@ find eg/ -type f -exec %{__chmod} a-x {} \;
 %{perl_vendorlib}/Net/DRI.pm
 
 %changelog
+* Fri Mar 12 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-71atomia
+- Fix transfer of .at domains. 
+
 * Wed Feb 10 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-70atomia
 - Get authcode directly from opensrs.
 

--- a/perl-Net-DRI.spec
+++ b/perl-Net-DRI.spec
@@ -10,7 +10,7 @@
 Summary: Interface to Domain Name Registries/Registrars/Resellers
 Name: perl-Net-DRI
 Version: 0.96
-Release: 71atomia
+Release: 72atomia
 License: Artistic/GPL
 Group: Applications/CPAN
 URL: http://search.cpan.org/dist/Net-DRI/
@@ -75,6 +75,9 @@ find eg/ -type f -exec %{__chmod} a-x {} \;
 %{perl_vendorlib}/Net/DRI.pm
 
 %changelog
+* Tue Jun 29 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-72atomia
+- Fix transfer of .at domains. 
+
 * Wed Apr 28 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-71atomia
 - Add support for DNSSEC in OpenSRS plugin.
 


### PR DESCRIPTION
Fixed transfer of .at domains.
Changed transfer command.

Resolves PROD-2557.

ChangeLog:

* [FIX] Fixed transfer of .at domains.