### PR TITLE
Add support for DNSSEC in OpenSRS plugin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
-libnet-dri-perl (0.96-70atomia) unstable; urgency=low
+libnet-dri-perl (0.96-71atomia) unstable; urgency=low
+  * Add support for DNSSEC in OpenSRS plugin.
   * Get authcode directly from opensrs.
   * Activate TLS1.2 on SWITCH plugin
   * Update domain-ext to 2.4 for EUrid.

--- a/lib/Net/DRI/DRD/OpenSRS.pm
+++ b/lib/Net/DRI/DRD/OpenSRS.pm
@@ -252,5 +252,12 @@ sub domain_get_authcode
  return $rc;
 }
 
+sub domain_get_dnssec_info
+{
+ my ($self,$ndr,$domain)=@_;
+ my $rc=$ndr->process('domain','get_dnssec_info',[$domain]);
+ return $rc;
+}
+
 ####################################################################################################
 1;

--- a/perl-Net-DRI.spec
+++ b/perl-Net-DRI.spec
@@ -10,7 +10,7 @@
 Summary: Interface to Domain Name Registries/Registrars/Resellers
 Name: perl-Net-DRI
 Version: 0.96
-Release: 70atomia
+Release: 71atomia
 License: Artistic/GPL
 Group: Applications/CPAN
 URL: http://search.cpan.org/dist/Net-DRI/
@@ -75,6 +75,9 @@ find eg/ -type f -exec %{__chmod} a-x {} \;
 %{perl_vendorlib}/Net/DRI.pm
 
 %changelog
+* Wed Apr 28 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-71atomia
+- Add support for DNSSEC in OpenSRS plugin.
+
 * Wed Feb 10 2021 Jovana Stamenkovic <jovana.stamenkovic@atomia.com> - 0.96-70atomia
 - Get authcode directly from opensrs.
 


### PR DESCRIPTION
Added support for DNSSEC in OpenSRS plugin.
Expanded thedomain update function in NET-DRI
to update DNSSEC records.
Added a new function that will return DNSSEC
records data.

Resolves PROD-1659 (1/2).

ChangeLog:
*[ADD] Added support for DNSSEC in OpenSRS plugin.